### PR TITLE
Add README info for LuaSocket installation on Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ every time that a submodule is updated.  These steps can be combined as
 `git submodule update --init`.
 
 The Minetest IRC mod also requires LuaSocket.  This can be installed using your
-package manager on many distributions, for example on Arch Linux:
+package manager on many distributions.
+
+Some examples:
+
+Arch Linux:
 
 	# pacman -S lua51-socket
 
+Ubuntu (tested on 14.04):
+
+        # apt-get install luarocks
+        # luarocks install luasocket
 
 Settings
 --------

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Arch Linux:
 
 Ubuntu (tested on 14.04):
 
-        # apt-get install luarocks
-        # luarocks install luasocket
+	# apt-get install luarocks
+	# luarocks install luasocket
 
 Settings
 --------


### PR DESCRIPTION
This drove me mad as none of the packages in Ubuntu would satisfy the LuaSocket dependency. Hopefully this info saves someone else from the same headache.