### PR TITLE
Enforce a message size limit

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -213,6 +213,5 @@ end
 
 function irc.queue(msg)
 	if not irc.connected then return end
-	irc.conn:queue(msg)
+	irc.conn:queue(msg:sub(1, 512))
 end
-


### PR DESCRIPTION
Forces all messages to be at most 512 bytes, to stop `cmd help all` from the `irc_commands` DoSing the server (making it quit with the message `RecvQ exceeded`).

This is done in the core IRC mod so it limits everything rather than just `irc_commands`.

Credit to @bigfoot547 for finding this vulnerability.