### PR TITLE
Add number of connected players to `players` command

### DIFF
--- a/botcmds.lua
+++ b/botcmds.lua
@@ -169,8 +169,10 @@ irc.register_bot_command("players", {
 		for _, player in pairs(players) do
 			table.insert(names, player:get_player_name())
 		end
-		return true, "Connected players: "
-				..table.concat(names, ", ")
+		return true, string.format("%d connected player(s): %s",
+			#players,
+			table.concat(names, ", "),
+		)
 	end
 })
 

--- a/botcmds.lua
+++ b/botcmds.lua
@@ -171,7 +171,7 @@ irc.register_bot_command("players", {
 		end
 		return true, string.format("%d connected player(s): %s",
 			#players,
-			table.concat(names, ", "),
+			table.concat(names, ", ")
 		)
 	end
 })


### PR DESCRIPTION
This PR aims to add the number of connected players to the `players` command so that it can provide more functionality. 